### PR TITLE
fixes #278 : enablement of Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.7"
@@ -6,7 +7,8 @@ python:
 before_script:
   - export PATH=$HOME/.local/bin:$PATH
 install:
-- pip install --upgrade pip tox-travis
+# if setuptools<17.1 installing even dependencies could fail
+- pip install --upgrade pip setuptools tox-travis
 - pip install .
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,38 @@
 sudo: false
-language: python
-python:
-  - "2.7"
-  - "3.5"
+cache: pip
+matrix:
+    include:
+        - os: linux
+          python: 2.7
+          env: TOXENV=pep8,py27,ansible-lint
+          language: python
+        - os: linux
+          python: 3.5
+          env: TOXENV=py35
+          language: python
+        - os: osx
+          sudo: required
+          language: generic
+          env: TOXENV=py27
 # command to install dependencies
-before_script:
-  - export PATH=$HOME/.local/bin:$PATH
+#before_script:
+#  - export PATH=$HOME/.local/bin:$PATH
 install:
 # if setuptools<17.1 installing even dependencies could fail
-- pip install --upgrade pip setuptools tox-travis
-- pip install .
+#- if [ "$TRAVIS_OS_NAME" == "osx" ]; then travis_retry wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh;bash miniconda.sh -b -p $HOME/miniconda; export PATH="$HOME/miniconda/bin:$PATH" ;  fi
+- |
+  set -e
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    rvm get stable
+    which python || travis_retry brew install python && brew link --overwrite python
+    which python
+    python --version
+  fi
+#- if [ "$TRAVIS_OS_NAME" != "osx" ]; then travis_retry pip install --upgrade pip setuptools ;  fi
+#- travis_retry pip install --upgrade tox-travis
+- travis_retry pip install --upgrade pip setuptools tox-travis
 # command to run tests
 script:
-- pip check
+# pip check disabled on MacOS because the version of pip that comes with conda does not support it yet
+- if [ "$TRAVIS_OS_NAME" != "osx" ]; then pip check; fi
 - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+# command to install dependencies
+before_script:
+  - export PATH=$HOME/.local/bin:$PATH
+install:
+- pip install --upgrade pip tox-travis
+- pip install .
+# command to run tests
+script:
+- pip check
+- tox

--- a/cli/clg.py
+++ b/cli/clg.py
@@ -501,7 +501,8 @@ class Spec(object):
         for spec_parser in self.spec_helper.iterate_parsers():
             if spec_parser['name'] in args:
                 parser_dict = args[spec_parser['name']]
-                for arg_name, arg_val in parser_dict.items():
+                for arg_name in list(parser_dict.keys()):
+                    arg_val = parser_dict[arg_name]
                     arg_spec = self.spec_helper.get_option_spec(
                         spec_parser['name'], arg_name)
                     yield (spec_parser['name'], parser_dict,

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -199,8 +199,7 @@ def load_yaml(filename, *search_paths):
     """
     path = None
     searched_files = []
-    files_to_search = map(
-        lambda search_path: os.path.join(search_path, filename), search_paths)
+    files_to_search = [os.path.join(x, filename) for x in search_paths]
 
     for filename in files_to_search:
         searched_files.append(os.path.abspath(filename))

--- a/plugins/callbacks/human_log.py
+++ b/plugins/callbacks/human_log.py
@@ -43,9 +43,6 @@ class CallbackModule(CallbackBase if ANSIBLE2 else object):
                     print("\n{0}: {1}".format(field, output_replace))
 
     def _format_output(self, output):
-        # Strip unicode
-        if type(output) == unicode:
-            output = output.encode('ascii', 'replace')
 
         # If output is a dict
         if type(output) == dict:
@@ -82,6 +79,9 @@ class CallbackModule(CallbackBase if ANSIBLE2 else object):
                 return "\n" + "\n".join(real_output)
             else:
                 return " ".join(real_output)
+
+        # Strip unicode
+        output = output.encode('ascii', 'replace')
 
         # Otherwise it's a string, (or an int, float, etc.) just return it
         return str(output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=11.3
+setuptools>=17.1
 pytz>=2016.3
 shade==1.13.2
 ansible==2.1.3.0,!=2.2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools>=17.1
 pytz>=2016.3
 shade==1.13.2
-ansible==2.1.3.0,!=2.2.0.0
+ansible>=2.2.0.0
 colorlog>=2.6.1
 PyYAML>=3.11
 yamlordereddictloader>=0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=17.1
+setuptools>=11.3
 pytz>=2016.3
 shade==1.13.2
 ansible>=2.2.0.0

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     entry_points={
         'console_scripts': generate_entry_scripts()
     },
+    setup_requires=['setuptools>=17.1'],
     install_requires=reqs,
     author='rhos-qe',
     author_email='rhos-qe-dept@redhat.com'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 pep8==1.7.0
 pytest>=2.8
-ansible-lint==2.7.0
+ansible-lint>=3.4.8

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -17,7 +17,7 @@ def test_get_config_dir_project_defaults(our_cwd_setup):
     file_default_options = conf_file.options('defaults')
     file_default_options.sort()
 
-    module_default_options = conf.DEFAULT_SECTIONS['defaults'].keys()
+    module_default_options = list(conf.DEFAULT_SECTIONS['defaults'].keys())
     module_default_options.sort()
 
     assert file_default_options == module_default_options, \

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -47,7 +47,7 @@ def test_yamls_file_locations(spec_app):
     assert locations[1] == file1.dirname
     assert locations[2] == os.getcwd()
 
-    files = yaml_file_arg.get_allowed_values()
+    files = list(yaml_file_arg.get_allowed_values())
 
     assert len(files) == 2
     assert files[0] == os.path.basename(file2.strpath)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,7 @@ def test_dict_merge():
 
     dict_merge(first_dict, second_dict)
 
-    assert not cmp(first_dict, expected_result)
+    assert first_dict == expected_result
 
 
 @pytest.mark.parametrize("first, second, expected", [
@@ -44,7 +44,7 @@ def test_dict_merge_none_resolver(first, second, expected):
     from cli.utils import dict_merge, ConflictResolver
 
     dict_merge(first, second, conflict_resolver=ConflictResolver.none_resolver)
-    assert not cmp(first, expected)
+    assert first == expected
 
 
 @pytest.mark.parametrize("haystack, output", [

--- a/tox.ini
+++ b/tox.ini
@@ -45,3 +45,10 @@ whitelist_externals =
     /bin/bash
     /usr/bin/bash
 commands = bash -c 'cd docs; make clean; make html'
+
+
+[travis]
+# Used by tox-travis in order to decide which tox targets to enable for each travis environment
+python =
+  2.7: pep8, py27, ansible-lint, docs
+  3.5: pep8, py35

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ sitepackages = True
 
 [testenv:ansible-lint]
 setenv = ANSIBLE_CONFIG={toxinidir}/ansible.cfg.example
-commands = bash -c "find roles playbooks -type f -name '*.y*ml' -print0 | xargs -r -t -0 -n1 ansible-lint -x ANSIBLE0006,ANSIBLE0007"
+commands = bash -c "find roles playbooks -type f -name '*.y*ml' -print0 | xargs -I FILE -t -0 -n1 ansible-lint -x ANSIBLE0006,ANSIBLE0007,ANSIBLE0010,ANSIBLE0011,ANSIBLE0012,ANSIBLE0013,ANSIBLE0014,ANSIBLE0015,ANSIBLE0016 FILE"
 whitelist_externals = bash
 
 [testenv:any-errors-fatal]
@@ -37,7 +37,7 @@ whitelist_externals = bash
 # H404,H405,H101,H233,H306,H401,H301,H236 Skipped until they gets fixed
 ignore = E125,E123,E129,H404,H405,H101,H233,H306,H401,H301,H236
 show-source = True
-exclude = .git,.venv,.tox,dist,docs,*egg,library
+exclude = .git,.venv,.tox,dist,docs,*egg,library,build
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt


### PR DESCRIPTION
Please excuse the size of this change but this was the only way to enable Travis while testing for py2 and py3. 

The current code of infrared is broken on py3 due to few bugs fixed by this change. I guess at this moment there is no gate for testing py3, but this patch enables one.

One change that may come bit weird is the upgrade of ansible to 2.2, that's needed because only Ansible 2.2 is py3 compatible.

Same applies to ansible-lint which was a very old version, upgrading it allowed us to run py3.