### PR TITLE
Add tags to network related virsh cleanup tasks

### DIFF
--- a/plugins/virsh/tasks/cleanup.yml
+++ b/plugins/virsh/tasks/cleanup.yml
@@ -58,6 +58,7 @@
   ignore_errors: yes
 
 - name: cleanup known-hosts by ip
+  tags: networks
   known_hosts:
       state: absent
       name: "{{ item.1.ipaddr }}"
@@ -69,6 +70,7 @@
   ignore_errors: yes
 
 - name: remove the networks we created
+  tags: networks
   virt_net:
       name: "{{ item.key }}"
       state: absent
@@ -76,6 +78,7 @@
   when: item.key not in ignore_virsh_nets
 
 - name: restore bridge
+  tags: networks
   include: restore_bridged_interface.yml
   with_dict: "{{ vm_nets.networks }}"
   vars:


### PR DESCRIPTION
This patch tags the tasks in the virsh/cleanup playbook
relate to network cleanup with 'networks'. This is useful
if you want to skip infrared's network configuration by
using Ansible's skip-tags option on the CLI.

Example:

infrared virsh --host-address 127.0.0.1 --host-key ~/.ssh/infrared \
--cleanup yes --ansible-args="skip-tags=networks"

The motivation here is I'm using infrared to provision an undercloud
VM but I have my own networking setup (custom bridges, switches, etc)
for baremetal and would prefer to manage it on my own.