### PR TITLE
Set hosts user for all undercloud hosts

### DIFF
--- a/plugins/tripleo-undercloud/create_user.yml
+++ b/plugins/tripleo-undercloud/create_user.yml
@@ -84,8 +84,9 @@
 
       - name: Update hosts user
         add_host:
-            name: "{{ inventory_hostname }}"
+            name: "{{ hostvars[item]['inventory_hostname'] }}"
             ansible_ssh_user: "{{ install.user.name }}"
+        with_items: "{{ groups['undercloud'] }}"
 
 - name: update inventory file
   hosts: localhost


### PR DESCRIPTION
When running infrared against an [undercloud] group that has more than one host, the Ansible "add_host"
directive by design will only run against one of those hosts, as it runs outside of the playbook loop.  Per Ansible documentation, add a "with" loop against all hosts in the "undercloud" group so that all undercloud entries in the inventory are updated.

Also I'm a red hatter but am not present in the redhat-openstack github group.