### PR TITLE
Provide timestamps when creating pytest_report

### DIFF
--- a/plugins/pytest-runner/pytest_run.yml
+++ b/plugins/pytest-runner/pytest_run.yml
@@ -4,7 +4,7 @@
   any_errors_fatal: true
   vars:
       repo_folder: 'pytest-repo/'
-      pytest_output_filename: 'pytest-results.xml'
+      pytest_output_filename: 'pytest-results-{{ ansible_date_time.date }}.xml'
   tasks:
       - name: Install packages
         become: true
@@ -30,7 +30,7 @@
 
       - name: Execute test
         ignore_errors: true
-        shell: pytest -v {{ repo_folder }}{{ test.file }} --junitxml={{ pytest_output_filename }} 2>&1
+        shell: pytest -v {{ repo_folder }}{{ test.file }} --junitxml={{ pytest_output_filename }} 2>&1 --tb=no -r fp
         when: test.run|default(False)
         register: pytest_execution
 


### PR DESCRIPTION
1) Because we can run pytest_run during job several times so we want to keep previous results
2) do not show stderr when run pytest, use logs