### PR TITLE
Make full string regex_replace compatible with Python 3

### DIFF
--- a/infrared/common/roles/cdn_registery/tasks/main.yml
+++ b/infrared/common/roles/cdn_registery/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: register to openstack repos
   vars:
       repo_list: "{{ subscriptions.common + (subscriptions[install_version|openstack_release] if not cdn_skip_openstack_repos else []) }}"
-      modified_list: "{{ repo_list | map('regex_replace', '(.*)', '--enable=\\1') | join(' ') }}"
+      modified_list: "{{ repo_list | map('regex_replace', '^(.*)$', '--enable=\\1') | join(' ') }}"
   command: "subscription-manager repos {{ modified_list }}"
 
 - name: refresh yum cache

--- a/plugins/openstack/provision_network_resources.yml
+++ b/plugins/openstack/provision_network_resources.yml
@@ -65,7 +65,7 @@
         os_router:
             cloud: "{{ provision.cloud | default(omit) }}"
             external_fixed_ips: "{{ item.value.external_fixed_ips | default(omit) }}"
-            interfaces: "{{ item.value.attach_subnets | map('regex_replace', '(.*)', provision.prefix + '\\1') | join(',') }}"
+            interfaces: "{{ item.value.attach_subnets | map('regex_replace', '^(.*)$', provision.prefix + '\\1') | join(',') }}"
             name: "{{ provision.prefix }}{{ item.value.name | default('router1') }}"
             network: "{{ openstack_networks[0].id }}"
             state: present

--- a/plugins/openstack/tasks/servers.yml
+++ b/plugins/openstack/tasks/servers.yml
@@ -32,7 +32,7 @@
       name: "{{ prefix }}{{ topology_node.name }}-{{ item|int - 1 }}"
       nics: "{{ nics.results | map(attribute='stdout') | list }}"
       key_name: "{{ provision.key.name if provision.key.name else (prefix + provision.key.file | basename) }}"
-      security_groups: "{{ secgroups | default([]) | map('regex_replace', '(.*)', prefix + '\\1') | list or omit }}"
+      security_groups: "{{ secgroups | default([]) | map('regex_replace', '^(.*)$', prefix + '\\1') | list or omit }}"
       state: present
       wait: "{{ topology_node.wait | default(wait) }}"
       timeout: "{{ provision.os.server.timeout | int }}"


### PR DESCRIPTION
Previously with Python 3 the replacement would glitch out and when
running IR with --prefix=jistr_test_ i'd get errors on provisioning
like:

"msg": "subnet jistr_test_external-subnetjistr_test_ not found"