### PR TITLE
Allow setting router network in OpenStack provisioner

### DIFF
--- a/plugins/openstack/provision_network_resources.yml
+++ b/plugins/openstack/provision_network_resources.yml
@@ -67,7 +67,7 @@
             external_fixed_ips: "{{ item.value.external_fixed_ips | default(omit) }}"
             interfaces: "{{ item.value.attach_subnets | map('regex_replace', '(.*)', provision.prefix + '\\1') | join(',') }}"
             name: "{{ provision.prefix }}{{ item.value.name | default('router1') }}"
-            network: "{{ openstack_networks[0].id }}"
+            network: "{{ item.value.network | default(openstack_networks[0].id) }}"
             state: present
         register: routers
         with_dict: "{{ networks_data.routers }}"


### PR DESCRIPTION
Previously infrared just selected the first network from the list of
networks to create the router on. If that happened to be a network
which was IPv6 only, we'd get an error like:

Bad floatingip request: Network does not contain any IPv4 subnet.

This autoselection is still the default behavior, but the network
topology configuration can override it via a variable in the router
config.