### PR TITLE
Fix specifying nics list to OpenStack provisioner

### DIFF
--- a/plugins/openstack/tasks/servers.yml
+++ b/plugins/openstack/tasks/servers.yml
@@ -30,7 +30,7 @@
       flavor: "{{ topology_node.flavor | default(flavor_id) }}"
       image: "{{ (topology_node.image|default({})).name | default(provision.image) }}"
       name: "{{ prefix }}{{ topology_node.name }}-{{ item|int - 1 }}"
-      nics: "{{ nics.results | map(attribute='stdout') | list }}"
+      nics: "{{ nics.results | map(attribute='stdout') | join(',') }}"
       key_name: "{{ provision.key.name if provision.key.name else (prefix + provision.key.file | basename) }}"
       security_groups: "{{ secgroups | default([]) | map('regex_replace', '(.*)', prefix + '\\1') | list or omit }}"
       state: present


### PR DESCRIPTION
Previously creating the BMC virtual machine resulted in error:

instance_id <ID> could not be found as device id on any ports

because the nics weren't passed into the module according to the
os_server docs. This is now fixed.