### PR TITLE
Circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2
+jobs:
+  build:
+    docker: &docker
+      - image: fedora:latest
+    steps:
+      - checkout
+  py27: &test
+    docker: *docker
+    steps:
+      - run:
+          name: Update system
+          command: dnf update -y
+      - run:
+          name: Install system dependencies
+          command: >-
+            dnf install -y python2 gcc python2-devel python3-devel
+            python{2,3}-libselinux libyaml-devel python3-tox python{2,3}-pbr
+            git openssh-clients
+      - checkout
+      - run:
+          name: Run tox tests
+          command: |
+            tox -e "${CIRCLE_JOB}"
+  pep8: *test
+  ansible-lint: *test
+  any-errors-fatal: *test
+  cli: *test
+  conflicts: *test
+  plugin-registry: *test
+  docs: *test
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - build
+        # Fan out to run these in parallel
+      - py27: &toxstep
+          requires:
+            - build
+      - pep8: *toxstep
+      - ansible-lint: *toxstep
+      - any-errors-fatal: *toxstep
+      - cli: *toxstep
+      - conflicts: *toxstep
+      - plugin-registry: *toxstep
+      - docs: *toxstep

--- a/docs/source/tripleo-overcloud.rst
+++ b/docs/source/tripleo-overcloud.rst
@@ -230,6 +230,7 @@ Tripleo Heat Templates configuration options
     should inject the following yaml to "overcloud deploy" command:
 
     .. code-block:: yaml
+
         ---
         parameter_defaults:
             ControllerExtraConfig:


### PR DESCRIPTION
Adds support for CI builds in Circle CI to help improve future testing.

Also fixes a syntax error in the docs, allowing them to build and pass testing. Once this is merged, CI building can be enabled through the Cirlce CI website by anyone with admin rights to this repository.