### PR TITLE
Go back to expanding /dev/sda1 by default.

### DIFF
--- a/plugins/virsh/tasks/vms_1_create_disk.yml
+++ b/plugins/virsh/tasks/vms_1_create_disk.yml
@@ -64,8 +64,7 @@
             # expand (copy-content) into new image in case of system disk
             # virt-resize needs target file with expected size to already exists
             os_version=`virt-cat -a {{ base_image_path }}/{{ image_name }} /etc/os-release | awk '/^VERSION=/ {print $1}' | grep -oP '[0-9]+' | head -1`
-            [[ $os_version -ge "8" ]] && partition="/dev/sda3" || partition="/dev/sda1"
-            virt-resize --expand $partition {{ base_image_path }}/{{ image_name }} {{ disk_pool }}/{{ node_image }}
+            virt-resize --expand /dev/sda1 {{ base_image_path }}/{{ image_name }} {{ disk_pool }}/{{ node_image }}
             # incjet DEFROUT to file and set it on for external network only
             virt-customize -a {{ disk_pool }}/{{ node_image }} \
             {% for interface in topology_node.interfaces %}


### PR DESCRIPTION
New-ish rhel8 images are back to the default setup with a single sda1 partition.

This commit removes the check and reverts to expanding /dev/sda1 by default.