### PR TITLE
Update repository information for 13 and 14

### DIFF
--- a/infrared/common/roles/cdn_registery/defaults/main.yml
+++ b/infrared/common/roles/cdn_registery/defaults/main.yml
@@ -3,9 +3,12 @@ subscriptions:
         - rhel-7-server-rpms
         - rhel-7-server-extras-rpms
         - rhel-7-server-rh-common-rpms
+    14:
+        - rhel-ha-for-rhel-7-server-rpms
+        - rhel-7-server-openstack-14-rpms
     13:
         - rhel-ha-for-rhel-7-server-rpms
-        - rhel-7-server-openstack-beta-rpms
+        - rhel-7-server-openstack-13-rpms
     12:
         - rhel-ha-for-rhel-7-server-rpms
         - rhel-7-server-openstack-12-rpms


### PR DESCRIPTION
repository information is a bit old and need an update for RHOSP13 and RHOSP14 which are already GA.