### PR TITLE
Fc/osp15 dci

### DIFF
--- a/infrared/common/roles/cdn_registery/defaults/main.yml
+++ b/infrared/common/roles/cdn_registery/defaults/main.yml
@@ -1,8 +1,14 @@
 subscriptions:
     common:
-        - rhel-7-server-rpms
-        - rhel-7-server-extras-rpms
-        - rhel-7-server-rh-common-rpms
+        7:
+            - rhel-7-server-rpms
+            - rhel-7-server-extras-rpms
+            - rhel-7-server-rh-common-rpms
+        8:
+            - rhel-8-for-x86_64-baseos-rpms
+            - rhel-8-for-x86_64-appstream-rpms
+            - fast-datapath-for-rhel-8-x86_64-rpms
+            - ansible-2-for-rhel-8-x86_64-rpms
     14:
         - rhel-ha-for-rhel-7-server-rpms
         - rhel-7-server-openstack-14-rpms

--- a/infrared/common/roles/cdn_registery/tasks/main.yml
+++ b/infrared/common/roles/cdn_registery/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: register to openstack repos
   vars:
-      repo_list: "{{ subscriptions.common + (subscriptions[install_version|openstack_release] if not cdn_skip_openstack_repos else []) }}"
+      repo_list: "{{ subscriptions.common[ansible_distribution_major_version|int] + (subscriptions[install_version|openstack_release] if not cdn_skip_openstack_repos else []) }}"
       modified_list: "{{ repo_list | map('regex_replace', '^(.*)$', '--enable=\\1') | join(' ') }}"
   command: "subscription-manager repos {{ modified_list }}"
 

--- a/plugins/tripleo-undercloud/tasks/prepare_uc_images.yml
+++ b/plugins/tripleo-undercloud/tasks/prepare_uc_images.yml
@@ -159,14 +159,14 @@
               path: "{{ working_dir }}/containers-prepare-parameter.yaml"
               regexp: '(^\ +)tag: .*'
               replace: "\\1tag: {{ container_env['container-image-prepare']['tag'] }}"
-      when: not install.registry.skip.puddle
+      when: container_env['container-image-prepare']['tag'] != 'AUTODETECT'
 
     - block:
         - name: set satellite namespace
           replace:
               path: "{{ working_dir }}/containers-prepare-parameter.yaml"
               regexp: '(^\ +)namespace.*'
-              replace: "\\1namespace: {{ install.registry.mirror }}"
+              replace: "\\1namespace: {{ install.registry.mirror }}/{{ registry_namespace }}"
 
         - name: set satellite prefix
           replace:


### PR DESCRIPTION
The features allowing to use the CDN, local repositories and local container images are broken for OSP15 (and maybe OSP14).

Please find here two patches to fix this.