### PR TITLE
Fixes required for running infrared against upshift

### DIFF
--- a/plugins/openstack/post.yml
+++ b/plugins/openstack/post.yml
@@ -33,6 +33,11 @@
       - name: gather facts once ssh is properly configured
         setup:
 
+      - name: Get physical interface names
+        command: find /sys/class/net -type l -not -lname '*virtual*' -printf '%f\n'
+        register: phys_nics
+        changed_when: false
+
       - name: setup unbooted nics
         vars:
             nic: "{{ hostvars[inventory_hostname]['ansible_' + item ] }}"
@@ -57,7 +62,7 @@
             dest: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
         become: yes
         when: not nic.ipv4|default(False)
-        with_items: "{{ ansible_interfaces | difference(['lo']) }}"
+        loop: "{{ phys_nics.stdout_lines }}"
         register: nics
 
       - name: start nics

--- a/plugins/openstack/roles/bmc/tasks/main.yml
+++ b/plugins/openstack/roles/bmc/tasks/main.yml
@@ -24,7 +24,9 @@
       - "provision.bmc is defined"
       - "provision.bmc.cdn is defined"
       - "bmc_rhos_release|openstack_distribution == 'OSP'"
-  become: yes
+  args:
+      apply:
+          become: yes
 
 - include_role:
       name: rhos-release

--- a/plugins/openstack/tasks/servers.yml
+++ b/plugins/openstack/tasks/servers.yml
@@ -22,7 +22,7 @@
 - name: Create instances
   vars:
       resources: "{{ lookup('file', inventory_dir + '/resources.yml') | from_yaml }}"
-      secgroups: "{% if provision.anti.spoofing | bool %}{{ topology_node.security_groups }}{% endif %}"
+      secgroups: "{{ topology_node.security_groups | default([]) | map('regex_replace', '^(.*)$', prefix + '\\1') | list }}"
   os_server:
       cloud: "{{ provision.cloud | default(omit) }}"
       auto_ip: "{{ topology_node.auto_ip | default(auto_ip) }}"
@@ -32,7 +32,12 @@
       name: "{{ prefix }}{{ topology_node.name }}-{{ item|int - 1 }}"
       nics: "{{ nics.results | map(attribute='stdout') | join(',') }}"
       key_name: "{{ provision.key.name if provision.key.name else (prefix + provision.key.file | basename) }}"
-      security_groups: "{{ secgroups | default([]) | map('regex_replace', '^(.*)$', prefix + '\\1') | list or omit }}"
+      # If anti.spoofing is False we don't want any security group to be
+      # applied. However, the os_server module will default security_groups to
+      # '[default]' if this parameter is omitted, so we only want to omit it if
+      # anti.spoofing is True. If port security is disabled we need to supply
+      # an empty value here, or this will fail.
+      security_groups: "{% if provision.anti.spoofing | bool %}{{ secgroups | default(omit) }}{% else %}{{ [] }}{% endif %}"
       state: present
       wait: "{{ topology_node.wait | default(wait) }}"
       timeout: "{{ provision.os.server.timeout | int }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ six
 # ----
 setuptools>=39.0.0
 pip>=10.0.1
-ansible>=2.7.5,<2.8.0
+ansible>=2.7.5
 shade>=1.28
 colorlog>=2.7.0
 PyYAML>=3.11


### PR DESCRIPTION
This branch contains a single fix for Ansible 2.8. With this single fix in place, I ran openstack provision, tripleo-undercloud and tripleo-overcloud with ansible 2.8.

It also contains 2 fixes related to idempotence when re-provisioning after partially deleting a deployment. Specifically:

* Deploy 1 bmc, 1 undercloud, 3 controllers, 2 computes with openstack provisioning
* Delete 3 controllers and 2 computes
* Run provisioning again
* Bugs

With these 2 fixes in place this works correctly.