### PR TITLE
openstack: Add undercloud node topology.

### DIFF
--- a/plugins/openstack/defaults/topology/nodes/undercloud.yml
+++ b/plugins/openstack/defaults/topology/nodes/undercloud.yml
@@ -1,0 +1,16 @@
+name: undercloud
+interfaces:
+    nic1:
+        network: "management"
+    nic2:
+        network: "data"
+    nic3:
+        network: "external"
+external_network: management
+
+security_groups:
+    - general_access
+
+groups:
+    - undercloud
+    - openstack_nodes


### PR DESCRIPTION
The ovb_undercloud scenario is not always required for
use cases such as predeployed Overcloud servers.