### PR TITLE
Use python instead of python3 for the undercloud.conf.sample path. Resolves #373

### DIFF
--- a/plugins/tripleo-undercloud/configure.yml
+++ b/plugins/tripleo-undercloud/configure.yml
@@ -8,8 +8,6 @@
       - osp_release: "{{ install.version|openstack_release }}"
       - conf_instack: '/usr/share/instack-undercloud/undercloud.conf.sample'
       - conf_oooclient: '/usr/share/python-tripleoclient/undercloud.conf.sample'
-      - conf_oooclient_py3: '/usr/share/python3-tripleoclient/undercloud.conf.sample'
-      - default_conf: "{{ (osp_release <= 13) | ternary(conf_instack, (osp_release < 15) | ternary(conf_oooclient, conf_oooclient_py3)) }}"
       - local_src: "{%- if conf.file|default('') -%}
                 {{ conf.file }}
                 {%- elif 'hypervisor' in groups.all or 'undercloud_hypervisors' in groups or 'bmc' in groups -%}
@@ -79,7 +77,7 @@
       - name: copy default undercloud config
         copy:
             remote_src: yes
-            src: "{{ default_conf }}"
+            src: "{{ conf_oooclient }}"
             dest: ~/undercloud.conf
             force: yes
             mode: 0755


### PR DESCRIPTION
For backwards compatiblity, TripleO no longer uses the python3 path.