### PR TITLE
[tripleo-undercloud] Set a default for overcloud_domain.

### DIFF
--- a/plugins/tripleo-undercloud/init.yml
+++ b/plugins/tripleo-undercloud/init.yml
@@ -17,13 +17,12 @@
 
     - name: set hostname
       hostname:
-          # todo(yfried): this seems highly specific. Refactor this to a more generic use case
-          name: "{{ inventory_hostname }}.redhat.local"
+          name: "{{ inventory_hostname }}.{{ install.overcloud.domain }}"
 
     - name: update /etc/hosts with undercloud details
       lineinfile:
           dest: "/etc/hosts"
-          line: "127.0.0.1   {{ inventory_hostname }}.redhat.local {{ inventory_hostname }}"
+          line: "127.0.0.1   {{ inventory_hostname }}.{{ install.overcloud.domain }} {{ inventory_hostname }}"
           state: present
 
 - import_playbook: create_user.yml

--- a/plugins/tripleo-undercloud/plugin.spec
+++ b/plugins/tripleo-undercloud/plugin.spec
@@ -128,7 +128,7 @@ subparsers:
                       help: |
                           DNS domain name to use when deploying the overcloud. The overcloud
                           parameter "CloudDomain" must be set to a matching value.
-                      default: ''
+                      default: 'redhat.local'
 
                   deploy_interface_default:
                       type: Value


### PR DESCRIPTION
This is in-line with the default from the tripleo-overcloud plugin.