### PR TITLE
Skip EC2 facts when deploying packstack

### DIFF
--- a/plugins/packstack/install.yml
+++ b/plugins/packstack/install.yml
@@ -33,6 +33,20 @@
             name: openstack-packstack
             state: present
 
+      # Disable EC2 facts https://bugzilla.redhat.com/show_bug.cgi?id=1842520
+      - name: Create facter config directory
+        file:
+            state: directory
+            path: /etc/puppetlabs/facter
+
+      - name: Create facter config file
+        copy:
+            dest: /etc/puppetlabs/facter/facter.conf
+            content: |
+              facts : {
+                blocklist: [ "EC2" ],
+              }
+
       - name: Generate answer file
         command: "packstack --gen-answer-file={{ answers_file }}"
 


### PR DESCRIPTION
As reported in [1], in some CI environments metadata server takes longer
that expected to reply. This patch is creating a facter config file to
disable EC2 facts.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1842520