### PR TITLE
Fix error message when validate required nic is present is false

### DIFF
--- a/plugins/virsh/tasks/bridged_network.yml
+++ b/plugins/virsh/tasks/bridged_network.yml
@@ -1,7 +1,7 @@
 # https://jamielinux.com/docs/libvirt-networking-handbook/bridged-network.html#bridged-network
 - name: validate required nic is present
   fail:
-      msg: "Cannot find bridge nic: {{ nic_name }}"
+      msg: "Cannot find bridge nic: Empty nic_data for {{ nic_settings }}. Have you configured override.networks with this NIC name, but the NIC does not exist on the server?"
   when: nic_data == ''
 
 - name: disable netfilter for bridges


### PR DESCRIPTION
The error message contained a reference to invalid variable
nic_name. This commit fixes this and provides a clue to what
might have gone wrong.

Closes issue #406

Signed-off-by: Andreas Karis <ak.karis@gmail.com>