### PR TITLE
Fix ObjectStorage role use

### DIFF
--- a/plugins/tripleo-overcloud/vars/deployment/files/virt/network/baremetal_deployment.yaml.j2
+++ b/plugins/tripleo-overcloud/vars/deployment/files/virt/network/baremetal_deployment.yaml.j2
@@ -309,7 +309,7 @@
 {% endif %}
 {% endif -%}
 {%- if install.storage.backend == 'swift' %}
-- name: SwiftStorage
+- name: ObjectStorage
   count: {{ (install.storage.nodes|default(0)) or (groups['swift']|default([])|length) or 1 }}
   hostname_format: swift-%index%
   defaults:


### PR DESCRIPTION
The role is named ObjectStorage, not SwiftStorage. This patch fixes this to ensure some of the deployment actions (like ObjectStorageExtraConfigPre) are actually executed.