### PR TITLE
Adding Ironic boot from ISO test

### DIFF
--- a/plugins/tempest/vars/tests/ironic_iso.yml
+++ b/plugins/tempest/vars/tests/ironic_iso.yml
@@ -1,0 +1,22 @@
+---
+test_dict:
+    test_regex:
+      default: ironic_tempest_plugin.tests.scenario.ironic_standalone.test_ramdisk_iso
+
+    whitelist: []
+    blacklist: []
+        - "^ironic_tempest_plugin.tests.scenario.ironic_standalone.test_ramdisk_iso.BaremetalRamdiskBootIsoVMedia.test_ramdisk_boot"
+    plugins:
+      ironic_tests:
+        repo: "https://opendev.org/openstack/ironic-tempest-plugin.git"
+        package:
+            9: "python-ironic-tests"
+            10: "python-ironic-tests"
+            11: "python-ironic-tests"
+            12: "python-ironic-tests"
+            13: "python2-ironic-tests-tempest"
+            14: "python2-ironic-tests-tempest"
+            default: "python3-ironic-tests-tempest"
+        dependencies:
+          - postgresql-devel
+          - libjpeg-devel

--- a/plugins/tempest/vars/tests/ironic_scenario.yml
+++ b/plugins/tempest/vars/tests/ironic_scenario.yml
@@ -5,6 +5,7 @@ test_dict:
 
     whitelist:
         - "^ironic_tempest_plugin.tests.scenario.test_baremetal_basic_ops.BaremetalBasicOpsAndRescue.test_baremetal_server_ops_wholedisk_image"
+        - "^ironic_tempest_plugin.tests.scenario.ironic_standalone.test_ramdisk_iso.baremetalRamdiskBootIsoIPXE.test_ramdisk_boot"
     blacklist:
         - "^ironic_tempest_plugin.tests.scenario.test_baremetal_basic_ops.BaremetalBasicOps.test_baremetal_server_ops_wholedisk_image"
         - "^ironic_tempest_plugin.tests.scenario.test_baremetal_boot_from_volume.BaremetalBFV.test_baremetal_boot_from_volume"


### PR DESCRIPTION
Enabling Tempest test for booting
instances from ISO file

the edit in the vars file for ironic_scenario
can be backed out later if we want to keep
ironic_iso separate