### PR TITLE
Add IPv6 escaping for designate DNS servers

### DIFF
--- a/plugins/tempest/tasks/configure/run.yml
+++ b/plugins/tempest/tasks/configure/run.yml
@@ -89,7 +89,7 @@
               {# os_glance_reserved tests can be enabled since wallaby, see https://review.opendev.org/c/openstack/tempest/+/771071 #}
               image-feature-enabled.os_glance_reserved true \
               {% if (designate_port_ips.stdout_lines is defined) and  (designate_port_ips.stdout_lines | length > 0) %}
-              dns.nameservers {{ designate_port_ips.stdout_lines | join(',') }} \
+              dns.nameservers {{ designate_port_ips.stdout_lines | ansible.utils.ipwrap | join(',') }} \
               {% endif %}
               {% endif %}
               {# https://bugzilla.redhat.com/show_bug.cgi?id=1382048 #}


### PR DESCRIPTION
When deploying with IPv6 the nameservers entries aren't escaped properly causing the designate query client to mistake the final octet as a port number and throw an invalid literal error if contains an non-int character.

e.g.: invalid literal for int() with base 10: 'a9'