### PR TITLE
 Replace hard-coded CA install with tls-ca role in prepare_freeipa

### DIFF
--- a/infrared/common/roles/tls-everywhere/tasks/prepare_freeipa.yml
+++ b/infrared/common/roles/tls-everywhere/tasks/prepare_freeipa.yml
@@ -76,12 +76,12 @@
         - ansible_distribution in ['CentOS', 'RedHat']
         - ansible_distribution_major_version is version("9", "<")
 
-  - name: Install Red Hat CA
+  - name: Install Red Hat CA (using tls-ca role)
+    role: tls-ca
+    tlsca: "{{ install.tls.ca }}"
     become: yes
-    shell: |
-        update-ca-trust enable
-        curl https://password.corp.redhat.com/RH-IT-Root-CA.crt -o /etc/pki/ca-trust/source/anchors/2015-RH-IT-Root-CA.pem
-        update-ca-trust extract
+    become_user: root
+    when: install.tls.ca is defined and install.tls.ca != ''
 
   - name: Update repos
     become: yes


### PR DESCRIPTION
This PR refactors the FreeIPA setup by replacing a hard-coded shell task with the standardized tls-ca role.